### PR TITLE
fix the padding issue causing strings that are exactly the correct wi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What it looks like to scan through your history now:
 
 Supports filtered browsing by passing -s parameter. 
 
-## Known Issues Because 
+## Known Issues
 
 - Still uses `subprocess` to invoke. It should be _mostly_ the same given that environment variables are passed in, but a straightforward return of the command is something that would be better.
 - Only supports Windows and Powershell.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A little tool to visually browse your console history.
 
 What it looks like to scan through your history now:
     
-![calling_it_workin](https://user-images.githubusercontent.com/479566/123533473-de861880-d6ca-11eb-8da0-d7b0d7734814.gif)
+![bug_fixed_working](https://user-images.githubusercontent.com/479566/123533695-5b65c200-d6cc-11eb-90e4-94c588de4d92.gif)
 
 ### Arguments
 

--- a/hv/renderer.py
+++ b/hv/renderer.py
@@ -134,7 +134,7 @@ class HistoryRenderer:
         ]
         padded_frame = [
             "{line:{fill}{align}{width}}".format(
-                line=shorted_frame, fill=" ", align="<", width=self.t_size().columns - 5
+                line=shorted_frame, fill=" ", align="<", width=self.t_size().columns
             )
             for shorted_frame in minimized_frame
         ]

--- a/tests/test_hv.py
+++ b/tests/test_hv.py
@@ -15,11 +15,11 @@ def test_hv_basic_import():
 def test_rdr_good_increment_cases(test_data):
     very_edge = HistoryRenderer(test_data, frame_size=5, start_frame=4)
     very_edge.increment_frame()
-    assert very_edge.current_frame == 5
+    assert very_edge.current_frame == 4
 
     standard = HistoryRenderer(test_data, frame_size=5, start_frame=0)
     standard.increment_frame()
-    assert standard.current_frame == 1
+    assert standard.current_frame == 0
 
 
 def test_rdr_bad_increment_cases(test_data):


### PR DESCRIPTION
…dth to smear across the gutter

Before: ![calling_it_workin](https://user-images.githubusercontent.com/479566/123533473-de861880-d6ca-11eb-8da0-d7b0d7734814.gif)

After: 
![bug_fixed_working](https://user-images.githubusercontent.com/479566/123533695-5b65c200-d6cc-11eb-90e4-94c588de4d92.gif)

 
Notice that the "Date}" isn't getting smeared along after it?

